### PR TITLE
Add Sender Trace ID support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ make test-race
 
 ### Logging
 
-- Add request/response logging middleware
-- Add structured logging for both web and API
+- <del>Add request/response logging middleware</del> done
+- <del>Add structured logging for both web and API</del> done
 
 ### MusicBrainz API
 

--- a/pkg/middleware/request_context_middleware.go
+++ b/pkg/middleware/request_context_middleware.go
@@ -17,6 +17,11 @@ func RequestContextMiddleware(next http.Handler) http.Handler {
 		ctx := r.Context()
 		ctx = context.WithValue(ctx, util.TraceIDContextKey, traceID)
 
+		// The value of this header will be present in every log entries
+		if senderTraceID := r.Header.Get(util.HeaderSenderTraceID); senderTraceID != "" {
+			ctx = context.WithValue(ctx, util.SenderTraceIDContextKey, senderTraceID)
+		}
+
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/pkg/util/context.go
+++ b/pkg/util/context.go
@@ -3,5 +3,6 @@ package util
 type contextKey = string
 
 const (
-	TraceIDContextKey contextKey = "trace_id"
+	TraceIDContextKey       contextKey = "trace_id"
+	SenderTraceIDContextKey contextKey = "sender_trace_id"
 )

--- a/pkg/util/headers.go
+++ b/pkg/util/headers.go
@@ -1,0 +1,6 @@
+package util
+
+const (
+	// Optional header that can be used by clients to group together log entries
+	HeaderSenderTraceID = "Sender-Trace-Id"
+)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -30,7 +30,7 @@ func NewLogger() *Logger {
 	}
 }
 
-// Create a new logger that contains values stored in the context
+// Create a new logger that logs values stored in the context
 func (l *Logger) FromContext(ctx context.Context) *Logger {
 	if ctx == nil {
 		return l
@@ -41,12 +41,25 @@ func (l *Logger) FromContext(ctx context.Context) *Logger {
 		return l
 	}
 
-	// Log the trace_id if it is present in the context
-	newLogger := l.Logger.With(
+	// If sender_trace_id is not present, only log the trace_id retrieved above
+	senderTraceID, ok := ctx.Value(SenderTraceIDContextKey).(string)
+	if !ok {
+		logger := l.Logger.With(
+			slog.String("trace_id", traceID),
+		)
+
+		return &Logger{
+			Logger: logger,
+		}
+	}
+
+	// Log sender_trace_id and trace_id
+	logger := l.Logger.With(
 		slog.String("trace_id", traceID),
+		slog.String("sender_trace_id", senderTraceID),
 	)
 
 	return &Logger{
-		Logger: newLogger,
+		Logger: logger,
 	}
 }

--- a/web/app.go
+++ b/web/app.go
@@ -105,7 +105,7 @@ func SetupRoutes(serverCtx context.Context, router *http.ServeMux, options *Serv
 
 				// http client that integrate the feed api
 				feedClient := feed_api.NewFeedClient(options.apiHostname, options.apiPort)
-				if err := feedClient.SelectFeed(name, authCtx.Tokens.AccessToken); err == net.ErrNoAccess {
+				if err := feedClient.SelectFeed(ctx, name, authCtx.Tokens.AccessToken); err == net.ErrNoAccess {
 					logger.Error("select feed api call failed", "error", err)
 					http.Error(w, err.Error(), http.StatusUnauthorized)
 					return
@@ -148,14 +148,14 @@ func SetupRoutes(serverCtx context.Context, router *http.ServeMux, options *Serv
 				*/
 
 				feedClient := feed_api.NewFeedClient(options.apiHostname, options.apiPort)
-				if ok, err := feedClient.CheckHealth(); !ok {
+				if ok, err := feedClient.CheckHealth(ctx); !ok {
 					feedPage.Health = false
 					if err != nil {
 						logger.Error("feed api is down or unresponsive", "error", err)
 					}
 				} else {
 					// only query for feed if feed API is healthy
-					feed, err := feedClient.GetFeed(authCtx.Tokens.AccessToken)
+					feed, err := feedClient.GetFeed(ctx, authCtx.Tokens.AccessToken)
 					if err != nil {
 						logger.Error("feed api call failed", "error", err)
 						http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Clients now have the ability to set a sender trace id (or called id). This id will then be present in any log entries.  